### PR TITLE
Add TREASURY-TRANSACTION-DETAILS-V3-URL to environment variables in values.yaml

### DIFF
--- a/deploy-as-code/charts/core-services/etreasury/values.yaml
+++ b/deploy-as-code/charts/core-services/etreasury/values.yaml
@@ -153,3 +153,8 @@ env: |
       secretKeyRef:
         name: etreasury
         key: treasury-reconciliation-v3-source
+  - name: TREASURY-TRANSACTION-DETAILS-V3-URL
+    valueFrom:
+      configMapKeyRef:
+        name: egov-config
+        key: treasury-transaction-details-v3-url


### PR DESCRIPTION
## Summary
- Cherry-pick of commit cab61a2 from `stg-to-prod-jul-3` onto `solutions-dev`
- Adds `TREASURY-TRANSACTION-DETAILS-V3-URL` to environment variables in `deploy-as-code/charts/core-services/etreasury/values.yaml`

## Note
- `solutions-dev`'s values.yaml was missing an unrelated pre-existing block of TREASURY mock-config env vars (`TREASURY_PUBLIC_KEY`, `TREASURY_CLIENT_ID`, etc.) that other branches have. This PR applies only the intended change from cab61a2 and does not introduce that unrelated block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)